### PR TITLE
build(webpack): Remove React from bundle

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -7,6 +7,16 @@ module.exports = {
     filename: "index.js",
     libraryTarget: "umd"
   },
+  externals: [
+    {
+      react: {
+        root: "React",
+        commonjs2: "react",
+        commonjs: "react",
+        amd: "react"
+      }
+    }
+  ],
   module: {
     loaders: [
       {


### PR DESCRIPTION
Remove React from bundle. This reduces the package size from 97.7 kB to 46.3 kB.